### PR TITLE
Relax atom construction check

### DIFF
--- a/opencog/atoms/core/Checkers.cc
+++ b/opencog/atoms/core/Checkers.cc
@@ -98,6 +98,9 @@ bool check_numeric(const Handle& bool_atom)
 		// Oddly enough, sets of numbers are allowed.
 		if (SET_LINK == t and check_numeric(h)) continue;
 
+		// Allows to add, subtract, etc functions (used by as-moses)
+		if (SCHEMA_NODE == t) continue;
+
 		if (QUOTE_LINK == t) continue;
 		if (UNQUOTE_LINK == t) continue;
 

--- a/opencog/atoms/core/Checkers.cc
+++ b/opencog/atoms/core/Checkers.cc
@@ -56,8 +56,16 @@ bool check_evaluatable(const Handle& bool_atom)
 		if (VARIABLE_NODE == t) continue;
 		if (DEFINED_PREDICATE_NODE == t) continue;
 
-		// XXX This is kind-of pushing it, but OK, allow PredicateNode
+		// Allow conjunction, disjunction and negation of
+		// predicates. Since it cannot inherit from EVALUATABLE_LINK
+		// (cause it's a Node) we have to add it here.
 		if (PREDICATE_NODE == t) continue;
+
+		// Allow conjunction, disjunction and negation of concepts as
+		// well, in that case these are interpreted as intersection,
+		// union and complement. Since it cannot inherit from
+		// EVALUATABLE_LINK (cause it's a Node) we have to add it here.
+		if (CONCEPT_NODE == t) continue;
 
 		// Fucking quote links. I hate those with a passion.
 		if (QUOTE_LINK == t) continue;

--- a/opencog/atoms/proto/atom_types.script
+++ b/opencog/atoms/proto/atom_types.script
@@ -100,7 +100,7 @@ TYPE_OUTPUT_LINK <- LINK
 
 // ===========================================================
 // Basic set-theory-inspired links
-SET_LINK <- UNORDERED_LINK
+SET_LINK <- UNORDERED_LINK,EVALUATABLE_LINK
 LIST_LINK <- ORDERED_LINK
 MEMBER_LINK <- ORDERED_LINK,EVALUATABLE_LINK
 
@@ -335,7 +335,7 @@ PATTERN_LINK <- PRENEX_LINK         // A pattern encapsulated in a Link.
 // executed.  The distinction is made for the benefit of the C++ code,
 // so that it can dispatch appropriately, based on the base type.
 SATISFACTION_LINK <- PATTERN_LINK,EVALUATABLE_LINK  // Finds all groundings, return TV
-SATISFYING_LINK <- PATTERN_LINK    // Finds all groundings, return SetLink
+SATISFYING_LINK <- PATTERN_LINK,EVALUATABLE_LINK    // Finds all groundings, return SetLink
 
 // The GetLink is almost exactly the same thing as a SatsifyingSetLink,
 // except that GetLink is imperative, while SatisfyingSetLink is
@@ -368,14 +368,14 @@ EXISTS_LINK <- SCOPE_LINK,EVALUATABLE_LINK
 SATISFYING_SET_SCOPE_LINK <- SCOPE_LINK
 
 // Convert predicate into concept
-SATISFYING_SET_LINK <- LINK
+SATISFYING_SET_LINK <- LINK,EVALUATABLE_LINK
 
 // Basic first-order logic operations
 
 // Sugar forms of implication and equivalence links. See
 // http://wiki.opencog.org/wikihome/index.php/ImplicationLink
 // for more information
-IMPLICATION_SCOPE_LINK <- SCOPE_LINK
+IMPLICATION_SCOPE_LINK <- SCOPE_LINK,EVALUATABLE_LINK
 INTENSIONAL_IMPLICATION_SCOPE_LINK <- IMPLICATION_SCOPE_LINK
 EXTENSIONAL_IMPLICATION_SCOPE_LINK <- IMPLICATION_SCOPE_LINK
 


### PR DESCRIPTION
Allows things like
```
And
  Concept "A"
  Concept "B"
```
```
Plus
  Schema "f1"
  Schema "f2"
```
(useful for as-moses), and more.
