### PR TITLE
Speed up circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
           name: Install AtomSpace
           command: cd build && make -j2 install && ldconfig
       - run:
+          name: Build examples
+          command: cd build && make -j2 examples
+      - run:
           name: Build tests
           command: cd build && make -j2 tests
       - run:


### PR DESCRIPTION
Saves a couple of minutes by running unit tests with 2 threads.

Compile the examples as well.