### PR TITLE
GroundedPredicateNode lib: support is added

### DIFF
--- a/opencog/atoms/execution/CMakeLists.txt
+++ b/opencog/atoms/execution/CMakeLists.txt
@@ -13,6 +13,7 @@ ADD_LIBRARY (execution
 	Instantiator.cc
 	MapLink.cc
 	ExecSCM.cc
+	LibraryManager.cc
 )
 
 # Without this, parallel make will race and crap up the generated files.

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -40,6 +40,7 @@
 
 #include "Force.h"
 #include "EvaluationLink.h"
+#include "LibraryManager.h"
 
 using namespace opencog;
 
@@ -573,6 +574,11 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 	return do_evaluate(as, sna[0], sna[1], silent);
 }
 
+// Fixme: added here, because lang_lib_fun is declared inside ExecutionOutputLink class
+// It would be better to move lang_lib_fun to LibraryManager, but BackwardChainer also
+// uses this function, so more refactoring would be needed
+#include "ExecutionOutputLink.h"
+
 /// do_evaluate -- evaluate the GroundedPredicateNode of the EvaluationLink
 ///
 /// Expects "pn" to be a GroundedPredicateNode or a DefinedPredicateNode
@@ -686,20 +692,26 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 #endif /* HAVE_CYTHON */
 	}
 
+	// Extract the language, library and function
+	std::string lang, lib, fun;
+	ExecutionOutputLink::lang_lib_fun(schema, lang, lib, fun);
+#define BROKEN_CODE
 #ifdef BROKEN_CODE
-	// Used by the Haskel bindings
-	// See ExecutionOutputLink.cc lines 174-187 for more
-	// code that partly implements this.
+	// Used by the C++ bindings; can be used with any language, Haskel binding is now missing
 	if (lang == "lib")
 	{
 		void* sym = LibraryManager::getFunc(lib,fun);
-
 		// Convert the void* pointer to the correct function type.
-		Handle* (*func)(AtomSpace*, Handle*);
-		func = reinterpret_cast<Handle* (*)(AtomSpace *, Handle*)>(sym);
-
-		// Execute the function
-		result = *func(as, &args);
+		TruthValuePtr* (*func)(AtomSpace*, Handle*);
+		func = reinterpret_cast<TruthValuePtr* (*)(AtomSpace *, Handle*)>(sym);
+		// Evaluate the predicate
+		TruthValuePtr* res = func(as, &args);
+		if(res != NULL)
+		{
+			TruthValuePtr result = *res;
+			free(res);
+			return result;
+		}
 	}
 #endif
 
@@ -714,3 +726,8 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 // faults.  I suppose that perhaps this needs to be fixed, but its
 // daunting at this time.
 // DEFINE_LINK_FACTORY(EvaluationLink, EVALUATION_LINK)
+
+void opencog::setLocalPredicate(std::string funcName, TruthValuePtr* (*func)(AtomSpace *, Handle*))
+{
+	LibraryManager::setLocalFunc("", funcName, reinterpret_cast<void*>(func));
+}

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -68,6 +68,12 @@ static inline EvaluationLinkPtr EvaluationLinkCast(AtomPtr a)
 
 #define createEvaluationLink std::make_shared<EvaluationLink>
 
+/**
+ * setLocalPredicate("foo", boo) enables creating GroundedPredicateNode with the name "lib:\\foo",
+ * which will call boo on evaluation of corresponding EvaluationLink.
+ */
+void setLocalPredicate(std::string funcName, TruthValuePtr* (*func)(AtomSpace *, Handle*));
+
 /** @}*/
 }
 

--- a/opencog/atoms/execution/LibraryManager.cc
+++ b/opencog/atoms/execution/LibraryManager.cc
@@ -1,0 +1,70 @@
+/*
+ * opencog/atoms/execution/LibraryManager.cc
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "LibraryManager.h"
+
+using namespace opencog;
+
+std::unordered_map<std::string, void*> LibraryManager::_librarys;
+std::unordered_map<std::string, void*> LibraryManager::_functions;
+
+void LibraryManager::setLocalFunc(std::string libName, std::string funcName, void* func)
+{
+	if (_librarys.count(libName) == 0) {
+		_librarys[libName] = NULL;
+	}
+	std::string funcID = libName + "\\" + funcName;
+	_functions[funcID] = func;
+}
+
+void* LibraryManager::getFunc(std::string libName,std::string funcName)
+{
+	void* libHandle;
+	if (_librarys.count(libName) == 0) {
+		// Try and load the library and function.
+		libHandle = dlopen(libName.c_str(), RTLD_LAZY);
+		if (nullptr == libHandle)
+			throw RuntimeException(TRACE_INFO,
+			                       "Cannot open library: %s - %s", libName.c_str(), dlerror());
+		_librarys[libName] = libHandle;
+	}
+	else {
+		libHandle = _librarys[libName];
+	}
+
+	std::string funcID = libName + "\\" + funcName;
+
+	void* sym;
+	if (_functions.count(funcID) == 0){
+		sym = dlsym(libHandle, funcName.c_str());
+		if (nullptr == sym)
+			throw RuntimeException(TRACE_INFO,
+			                       "Cannot find symbol %s in library: %s - %s",
+			                       funcName.c_str(), libName.c_str(), dlerror());
+		_functions[funcID] = sym;
+	}
+	else {
+		sym = _functions[funcID];
+	}
+
+	return sym;
+}

--- a/opencog/atoms/execution/LibraryManager.h
+++ b/opencog/atoms/execution/LibraryManager.h
@@ -1,0 +1,39 @@
+/*
+ * opencog/atoms/execution/LibraryManager.h
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_LIBRARAY_MANAGER_H
+#define _OPENCOG_LIBRARAY_MANAGER_H
+
+#include <dlfcn.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+class LibraryManager
+{
+private:
+	static std::unordered_map<std::string, void*> _librarys;
+	static std::unordered_map<std::string, void*> _functions;
+public:
+	static void* getFunc(std::string libName,std::string funcName);
+	static void setLocalFunc(std::string libName, std::string funcName, void* func);
+};
+
+#endif //_OPENCOG_LIBRARAY_MANAGER_H

--- a/tests/atoms/GroundedSchemaLocalUTest.cxxtest
+++ b/tests/atoms/GroundedSchemaLocalUTest.cxxtest
@@ -22,6 +22,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/execution/ExecutionOutputLink.h>
+#include <opencog/atoms/execution/EvaluationLink.h>
 
 using namespace opencog;
 
@@ -52,7 +53,8 @@ public:
 	void setUp();
 	void tearDown();
 
-	void test_local_func();
+	void test_local_schema();
+	void test_local_predicate();
 };
 
 void GroundedSchemaLocalUTest::tearDown()
@@ -73,7 +75,7 @@ Handle* safe_car(AtomSpace* as, Handle* params)
 	                  params->atom_ptr()->getOutgoingSet()[0]);
 }
 
-void GroundedSchemaLocalUTest::test_local_func()
+void GroundedSchemaLocalUTest::test_local_schema()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -86,11 +88,44 @@ void GroundedSchemaLocalUTest::test_local_func()
 		    N(CONCEPT_NODE, "Arg1"),
 		    N(CONCEPT_NODE, "Arg2"),
 		    N(CONCEPT_NODE, "Arg3"))
-			);
+		    );
 	Handle result = ((ExecutionOutputLink *)(eol.atom_ptr()))->execute(as, false);
 	logger().debug() << "Result is this:\n" << result->to_string();
 	Handle expected = N(CONCEPT_NODE, "Arg1");
 
 	TS_ASSERT_EQUALS(expected, result);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+TruthValuePtr* is_square(AtomSpace* as, Handle* params)
+{
+	HandleSeq args = params->atom_ptr()->getOutgoingSet();
+	int val1 = std::stoi(args[0].atom_ptr()->get_name());
+	int val2 = std::stoi(args[1].atom_ptr()->get_name());
+	// it is necessary to allocate memory for TruthValuePtr*
+	return new TruthValuePtr(val1 == val2 * val2 ? TruthValue::TRUE_TV() : TruthValue::FALSE_TV());
+}
+
+void GroundedSchemaLocalUTest::test_local_predicate()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	setLocalPredicate("is_square", is_square);
+
+	Handle gpn = N(GROUNDED_PREDICATE_NODE, "lib:\\is_square");
+	Handle args1 = L(LIST_LINK, N(NUMBER_NODE, "9"), N(NUMBER_NODE, "3"));
+	Handle args2 = L(LIST_LINK, N(NUMBER_NODE, "8"), N(NUMBER_NODE, "3"));
+
+	Handle evl1 = L(EVALUATION_LINK, gpn, args1);
+	Handle evl2 = L(EVALUATION_LINK, gpn, args2);
+
+	TruthValuePtr result1 = ((EvaluationLink *)(evl1.atom_ptr()))->evaluate(as);
+	TruthValuePtr result2 = ((EvaluationLink *)(evl2.atom_ptr()))->evaluate(as);
+	logger().debug() << "Result is this:\n" << result1->to_string() << "\n" << result2->to_string();
+	TruthValuePtr expected1 = TruthValue::TRUE_TV();
+	TruthValuePtr expected2 = TruthValue::FALSE_TV();
+
+	TS_ASSERT(*expected1 == *result1);
+	TS_ASSERT(*expected2 == *result2);
 	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
What was done:
* LibraryManager class is moved to a separate file
* void setLocalPredicate(std::string funcName, TruthValuePtr* (*func)(AtomSpace *, Handle *)) interface function is added
* EvaluationLink::do_evaluate is fixed to deal with "lib:" groundings
* Unit test for setLocalPredicate and do_evaluate with "lib:" is added

What has not been done:
* std::unordered_map<std::string, void*> LibraryManager::_functions was not separated into _schemas and _predicates to keep things more uniform, so predicates and schemas cannot have same names
* lang_lib_fun was kept in ExecutionOutputLink, because it is also used by BackwardChainer, although it might be nicer to move it to LibraryManager
* Haskel bindings were not extended yet to support GroundedPredicates
* BROKEN_CODE macros has not been removed yet