### PR TITLE
GroundedPredicate binding for Haskell

### DIFF
--- a/opencog/haskell/OpenCog/AtomSpace.hs
+++ b/opencog/haskell/OpenCog/AtomSpace.hs
@@ -36,8 +36,10 @@ module OpenCog.AtomSpace
     , module OpenCog.AtomSpace.Sugar
     -- * Function for use in GSN
     , exportFunction
+    , exportPredicate
     , Handle
     , HandleSeq
+    , TruthValueP
     , AtomSpaceRef
     -- * Utility Functions for working with Atoms
     , atomMap
@@ -55,4 +57,4 @@ import OpenCog.AtomSpace.Env
 import OpenCog.AtomSpace.Utils
 import OpenCog.AtomSpace.Sugar
 import OpenCog.AtomSpace.Query
-import OpenCog.AtomSpace.Internal    (Handle,HandleSeq)
+import OpenCog.AtomSpace.Internal    (Handle,HandleSeq,TruthValueP)

--- a/opencog/haskell/OpenCog/AtomSpace/Internal.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Internal.hs
@@ -9,6 +9,7 @@
 module OpenCog.AtomSpace.Internal (
       Handle(..)
     , HandleSeq(..)
+    , TruthValueP(..)
     , TVRaw(..)
     , fromTVRaw
     , toTVRaw
@@ -23,6 +24,7 @@ import OpenCog.AtomSpace.Types       (AtomName(..),AtomType(..)
                                      ,Atom(..),TruthVal(..))
 type Handle = Ptr ()
 type HandleSeq = Ptr Handle
+type TruthValueP = Ptr ()
 -- Constant with the maximum number of parameters in any type of TV.
 tvMAX_PARAMS :: Int
 tvMAX_PARAMS = 5

--- a/opencog/haskell/TruthValue_CWrapper.cpp
+++ b/opencog/haskell/TruthValue_CWrapper.cpp
@@ -20,15 +20,19 @@ int TruthValue_setOnAtom( Handle* atom
     Handle h = *atom;
     if (!h) // Invalid UUID parameter.
         return -1;
+    h->setTruthValue(TruthValuePtr_fromRaw(type,parameters));
 
+    return 0;
+}
+
+TruthValuePtr TruthValuePtr_fromRaw(const char* type, double* parameters)
+{
     if (strcmp(type,"SimpleTruthValue") == 0) {
-        h->setTruthValue(SimpleTruthValue::createTV(parameters[0],parameters[1]));
+        return SimpleTruthValue::createTV(parameters[0],parameters[1]);
     }
     else
     if (strcmp(type,"CountTruthValue") == 0) {
-        h->setTruthValue(CountTruthValue::createTV(parameters[0]
-                                                  ,parameters[1]
-                                                  ,parameters[2]));
+        return CountTruthValue::createTV(parameters[0],parameters[1],parameters[2]);
     }
     else
     if (strcmp(type,"IndefiniteTruthValue") == 0) {
@@ -38,20 +42,24 @@ int TruthValue_setOnAtom( Handle* atom
                                            ,parameters[3]);
         // iptr->setMean(parameters[0]);
         // iptr->setDiff(parameters[4]);
-        h->setTruthValue(std::static_pointer_cast<const TruthValue>(iptr));
+        return std::static_pointer_cast<const TruthValue>(iptr);
     }
     else
     if (strcmp(type,"FuzzyTruthValue") == 0) {
-        h->setTruthValue(FuzzyTruthValue::createTV(parameters[0],parameters[1]));
+        return FuzzyTruthValue::createTV(parameters[0],parameters[1]);
     }
     else
     if (strcmp(type,"ProbabilisticTruthValue") == 0) {
-        h->setTruthValue(ProbabilisticTruthValue::createTV(parameters[0]
-                                                          ,parameters[1]
-                                                          ,parameters[2]));
+        return ProbabilisticTruthValue::createTV(parameters[0],parameters[1],parameters[2]);
     }
     else
         throw InvalidParamException(TRACE_INFO,
                 ("Invalid TruthValue Type: " + std::string(type)).c_str());
-    return 0;
+}
+
+TruthValuePtr* PTruthValuePtr_fromRaw(const char* type, double* parameters)
+{
+    TruthValuePtr* result = (TruthValuePtr*)malloc(sizeof(TruthValuePtr));
+    *result = TruthValuePtr_fromRaw(type, parameters);
+    return result;
 }

--- a/opencog/haskell/TruthValue_CWrapper.h
+++ b/opencog/haskell/TruthValue_CWrapper.h
@@ -43,5 +43,25 @@ extern "C"
                             , const char* type
                             , double* parameters );
 
+    /**
+     * TruthValuePtr_fromRaw    Helper function that creates TruthValuePtr from RawTV
+     *
+     * @param      type        TruthValue type
+     * @param      parameters  List of parameters of the TV (strenght,confidence,...)
+     *
+     * @return  TruthValuePtr
+     */
+    TruthValuePtr TruthValuePtr_fromRaw(const char* type, double* parameters);
+
+    /**
+     * PTruthValuePtr_fromRaw    Function needed for GroundedPredicate Haskell binding that converts RawTV to TruthValuePtr*
+     *
+     * @param      type        TruthValue type
+     * @param      parameters  List of parameters of the TV (strenght,confidence,...)
+     *
+     * @return  TruthValuePtr*
+     */
+    TruthValuePtr* PTruthValuePtr_fromRaw(const char* type, double* parameters);
+
 }
 

--- a/tests/haskell/executionTestLib/src/OpenCog/Lib.hs
+++ b/tests/haskell/executionTestLib/src/OpenCog/Lib.hs
@@ -12,3 +12,13 @@ c_func = exportFunction someFunc
 
 someFunc :: Atom -> AtomSpace Atom
 someFunc a = pure a
+
+
+foreign export ccall "somePredicate"
+    c_pred :: Ptr AtomSpaceRef -> Handle -> IO (TruthValueP)
+
+c_pred = exportPredicate somePredicate
+
+somePredicate :: Atom -> TruthVal
+somePredicate (Link t xs tv) = tv
+somePredicate (Node t xs tv) = tv

--- a/tests/haskell/haskellTest/Main.hs
+++ b/tests/haskell/haskellTest/Main.hs
@@ -17,11 +17,12 @@ import System.Exit
 
 main :: IO ()
 main = do
-    testres <- executionOutputTest
-    case testres of
+    testres1 <- executionOutputTest
+    testres2 <- evaluationTest
+    case testres1 && testres2 of
         True -> exitSuccess
         False -> exitFailure
-
+        
 executionOutputTest :: IO Bool
 executionOutputTest = do
     curdir <- getCurrentDirectory
@@ -36,6 +37,22 @@ executionOutputTest = do
         Just (Link "ListLink" [Node "ConceptNode" "test" _] _) -> return True
         Just ares -> error $ "ExecutionOutputTest failed and returned: " ++ show ares
         Nothing ->error $ "ExecutionOutputTest failed and retruned Nothing"
+
+        
+evaluationTest :: IO Bool
+evaluationTest = do
+    curdir <- getCurrentDirectory
+    let atom = Link "EvaluationLink"
+                [Node "GroundedPredicateNode" ("lib: " ++ curdir ++
+                    "/libopencoglib-0.1.0.0.so\\somePredicate") noTv
+                ,Link "ListLink" [Node "ConceptNode" "test" noTv] (SimpleTV 0.5 0.5)
+                ] noTv
+        prog = insert atom >> evaluate atom
+    res <- runOnNewAtomSpace prog
+    case res of
+        Just (SimpleTV 0.5 0.5) -> return True
+        _ -> error $ "EvaluationTest failed and returned: " ++ show res
+
 
 myatom p = Link "ExecutionOutputLink"
                 [Node "GroundedSchemaNode" ("lib: " ++ p ++


### PR DESCRIPTION
What has been added:
* `TruthValueP` is added to Haskell binding library; it corresponds to `TruthValuePtr*` in C++, and do_evaluate expects that GroundedPredicate functions return this type
* `PTruthValuePtr_fromRaw` function is added to TruthValue_CWrapper (in C++); this function can be called from Haskell to convert RawTV (used in Haskell) to TruthValueP
* `convertTruthValueP` is added to Api.hs, which calls `PTruthValuePtr_fromRaw` preliminarily converting `TruthVal` to `TVRaw`
* `exportPredicate` is added to Api.hs, which makes `Atom -> TruthVal` Haskell function exportable (callable from `do_evaluate`)
* Lib.hs and Main.hs in tests/haskell are extended with GroundedPredicate evaluationTest that passes successfully
