### PR TITLE
Call python method with number of arguments from apply link

### DIFF
--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -185,3 +185,23 @@ ContentHash Link::compute_hash() const
 	_content_hash = hsh;
 	return _content_hash;
 }
+
+static void check_type(const ValuePtr& value, const Type& type, const std::string& location)
+{
+    if (!nameserver().isA(value->get_type(), type))
+    {
+        throw SyntaxException(TRACE_INFO,
+                "%s or subclass is expected as %s, actual parameter type is %s",
+                nameserver().getTypeName(type),
+                location,
+                nameserver().getTypeName(value->get_type()));
+    }
+}
+
+void Link::check_outgoing_type(int index, const Type& type)
+{
+    std::string location = std::to_string(index) + " outgoing link of " +
+        nameserver().getTypeName(get_type());
+    check_type(getOutgoingAtom(index), type, location);
+}
+

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -236,9 +236,9 @@ public:
 
     /**
      * Utility method to check type of the outgoing set item.
-     * \param index index of item in outgoing set
-     * \param type expected type of the item
-     * \throws SyntaxException if actual type is not equal to expected.
+     * @param index index of item in outgoing set
+     * @param type expected type of the item
+     * @throws SyntaxException if actual type is not equal to expected.
      */
     void check_outgoing_type(int index, const Type& type);
 };

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -233,6 +233,14 @@ public:
      * @return true if this atom is less than the given one, false otherwise.
      */
     virtual bool operator<(const Atom&) const;
+
+    /**
+     * Utility method to check type of the outgoing set item.
+     * \param index index of item in outgoing set
+     * \param type expected type of the item
+     * \throws SyntaxException if actual type is not equal to expected.
+     */
+    void check_outgoing_type(int index, const Type& type);
 };
 
 static inline LinkPtr LinkCast(const Handle& h)

--- a/opencog/atoms/execution/ApplyLink.cc
+++ b/opencog/atoms/execution/ApplyLink.cc
@@ -31,6 +31,11 @@ ApplyLink::ApplyLink(const HandleSeq& oset, Type t)
 {
 	forward_to_execution_output_link =
 		!nameserver().isA(get_schema()->get_type(), GROUNDED_FUNCTION_LINK);
+	if (!forward_to_execution_output_link)
+	{
+		check_outgoing_type(0, GROUNDED_FUNCTION_LINK);
+		check_outgoing_type(1, LIST_LINK);
+	}
 }
 
 ValuePtr ApplyLink::execute(AtomSpace* as, bool silent)

--- a/opencog/atoms/execution/MethodOfLink.cc
+++ b/opencog/atoms/execution/MethodOfLink.cc
@@ -26,25 +26,6 @@
 
 using namespace opencog;
 
-static void check_type(const ValuePtr& value, const Type& type, const std::string& location)
-{
-	if (!nameserver().isA(value->get_type(), type))
-	{
-		throw SyntaxException(TRACE_INFO,
-				"%s or subclass is expected as %s, actual parameter type is %s",
-				nameserver().getTypeName(type),
-				location,
-				nameserver().getTypeName(value->get_type()));
-	}
-}
-
-void MethodOfLink::check_outgoing_type(int index, const Type& type)
-{
-	std::string location = std::to_string(index) + " outgoing link of " + 
-		nameserver().getTypeName(get_type());
-	check_type(getOutgoingAtom(index), type, location);
-}
-
 MethodOfLink::MethodOfLink(const HandleSeq& output_set, Type type)
 	: GroundedFunctionLink(output_set, type)
 {

--- a/opencog/atoms/execution/MethodOfLink.h
+++ b/opencog/atoms/execution/MethodOfLink.h
@@ -34,8 +34,6 @@ private:
 	GroundedObject* get_object() const;
 	const std::string& get_method_name() const;
 
-	void check_outgoing_type(int index, const Type& type);
-
 public:
 	MethodOfLink(const HandleSeq& output_set, Type type);
 	virtual GroundedFunction get_function() const;

--- a/opencog/cython/opencog/grounded_object_node.pyx
+++ b/opencog/cython/opencog/grounded_object_node.pyx
@@ -1,4 +1,5 @@
-from opencog.atomspace cimport cCreateGroundedObjectNode, cPythonGroundedObject
+from opencog.atomspace cimport (cAtom, cCreateGroundedObjectNode,
+                                cPythonGroundedObject)
 from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string
 from cython.operator cimport dereference as deref
@@ -40,9 +41,9 @@ cdef api cValuePtr call_python_method(object obj, const string& method_name,
                                       cAtomSpace* atomspace, const cValuePtr&
                                       _args):
     method = getattr(obj, method_name.c_str().decode())
-    args = create_value_by_type(_args.get().get_type(),
-                                PtrHolder.create(<shared_ptr[void]&>_args),
-                                AtomSpace_factory(atomspace))
-    cdef Value result = method(args)
+    assert _args.get().is_link()
+    args = convert_handle_seq_to_python_list(
+        (<cAtom*>_args.get()).getOutgoingSet(), AtomSpace_factory(atomspace))
+    cdef Value result = method(*args)
     return result.get_c_value_ptr()
 

--- a/tests/cython/atomspace/test_groundedobjectnode.py
+++ b/tests/cython/atomspace/test_groundedobjectnode.py
@@ -17,24 +17,27 @@ class GroundedObjectNodeTest(unittest.TestCase):
         finalize_opencog()
         del self.space
 
-    def test_call_grounded_object_predicate(self):
-        grounded_object_node = GroundedObjectNode("test_grounded_object_node",
-                                                  TestObject("some object"))
+    def test_call_grounded_object_call(self):
         exec_link = ApplyLink(
-                        MethodOfLink(grounded_object_node, ConceptNode("foo")),
-                        ListLink(ConceptNode("arg"))
+                        MethodOfLink(
+                            GroundedObjectNode("obj", TestObject("obj")),
+                            ConceptNode("get_argument")
+                        ),
+                        ListLink(
+                            ConceptNode("arg")
                         )
+                    )
 
         result = execute_atom(self.space,  exec_link)
 
         self.assertEqual(result, ConceptNode("arg"))
 
     def test_call_grounded_object_no_arguments(self):
-        grounded_object_node = GroundedObjectNode("test_grounded_object_node",
-                                                  TestObject("some object"))
         exec_link = ApplyLink(
-                        MethodOfLink(grounded_object_node,
-                                     ConceptNode("noarguments")),
+                        MethodOfLink(
+                            GroundedObjectNode("obj", TestObject("obj")),
+                            ConceptNode("no_arguments")
+                        ),
                         ListLink()
                     )
 
@@ -43,29 +46,29 @@ class GroundedObjectNodeTest(unittest.TestCase):
         self.assertEqual(result, ConceptNode("empty"))
 
     def test_call_grounded_object_predicate_two_args(self):
-        grounded_object_node = GroundedObjectNode("test_grounded_object_node",
-                                                  TestObject("some object"))
         exec_link = ApplyLink(
-                        MethodOfLink(grounded_object_node, ConceptNode("second")),
+                        MethodOfLink(
+                            GroundedObjectNode("obj", TestObject("obj")),
+                            ConceptNode("get_second")
+                        ),
                         ListLink(
-                            ConceptNode("firstArg"),
-                            ConceptNode("secondArg")
+                            ConceptNode("first"),
+                            ConceptNode("second")
                         )
                     )
 
         result = execute_atom(self.space,  exec_link)
 
-        self.assertEqual(result, ConceptNode("secondArg"))
+        self.assertEqual(result, ConceptNode("second"))
 
     def test_set_object(self):
-        grounded_object_node = GroundedObjectNode("test_grounded_object_node",
-                                                  TestObject("some object"))
+        grounded_object_node = GroundedObjectNode("a", TestObject("some object"))
         grounded_object_node.set_object(TestObject("other object"))
 
         self.assertEqual(grounded_object_node.get_object().name, "other object")
 
     def test_create_grounded_object_node_without_object(self):
-        grounded_object_node = GroundedObjectNode("test_grounded_object_node")
+        grounded_object_node = GroundedObjectNode("obj")
 
         self.assertTrue(grounded_object_node.get_object() is None)
 
@@ -74,13 +77,13 @@ class TestObject:
     def __init__(self, name):
         self.name = name
 
-    def foo(self, arg):
+    def get_argument(self, arg):
         return arg
 
-    def noarguments(self):
+    def no_arguments(self):
         return ConceptNode("empty")
 
-    def second(self, first, second):
+    def get_second(self, first, second):
         return second
 
 if __name__ == '__main__':

--- a/tests/cython/atomspace/test_groundedobjectnode.py
+++ b/tests/cython/atomspace/test_groundedobjectnode.py
@@ -29,6 +29,34 @@ class GroundedObjectNodeTest(unittest.TestCase):
 
         self.assertEqual(result, ConceptNode("arg"))
 
+    def test_call_grounded_object_no_arguments(self):
+        grounded_object_node = GroundedObjectNode("test_grounded_object_node",
+                                                  TestObject("some object"))
+        exec_link = ApplyLink(
+                        MethodOfLink(grounded_object_node,
+                                     ConceptNode("noarguments")),
+                        ListLink()
+                    )
+
+        result = execute_atom(self.space,  exec_link)
+
+        self.assertEqual(result, ConceptNode("empty"))
+
+    def test_call_grounded_object_predicate_two_args(self):
+        grounded_object_node = GroundedObjectNode("test_grounded_object_node",
+                                                  TestObject("some object"))
+        exec_link = ApplyLink(
+                        MethodOfLink(grounded_object_node, ConceptNode("second")),
+                        ListLink(
+                            ConceptNode("firstArg"),
+                            ConceptNode("secondArg")
+                        )
+                    )
+
+        result = execute_atom(self.space,  exec_link)
+
+        self.assertEqual(result, ConceptNode("secondArg"))
+
     def test_set_object(self):
         grounded_object_node = GroundedObjectNode("test_grounded_object_node",
                                                   TestObject("some object"))
@@ -42,10 +70,18 @@ class GroundedObjectNodeTest(unittest.TestCase):
         self.assertTrue(grounded_object_node.get_object() is None)
 
 class TestObject:
+
     def __init__(self, name):
         self.name = name
-    def foo(self, args):
-        return args.out[0]
+
+    def foo(self, arg):
+        return arg
+
+    def noarguments(self):
+        return ConceptNode("empty")
+
+    def second(self, first, second):
+        return second
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Unpack `ApplyLink` list of argument to call Python method with positional arguments as usual.
Ensure that second argument of the `ApplyLink` is always `ListLink`, it is NOT similar to `ExecutionOutputLink` implementation, but doesn't have ambiguities.
If it is not comfortable to have such restriction we can discuss it further. 