### PR TITLE
Fix double free for python grounded object node

### DIFF
--- a/opencog/cython/opencog/PythonGroundedObject.cc
+++ b/opencog/cython/opencog/PythonGroundedObject.cc
@@ -41,7 +41,7 @@ static void load_cython_proxies()
 	import_opencog__atomspace();
 }
 
-PythonGroundedObject::PythonGroundedObject(PyObject *object, bool unwrap_args)
+PythonGroundedObject::PythonGroundedObject(void *object, bool unwrap_args)
 	: object(object)
 	, unwrap_args(unwrap_args)
 {

--- a/opencog/cython/opencog/PythonGroundedObject.h
+++ b/opencog/cython/opencog/PythonGroundedObject.h
@@ -33,19 +33,19 @@ class PythonGroundedObject : public GroundedObject
 {
 private:
 
-	PyObject* object;
+	void* object;
 	bool unwrap_args;
 
 public:
 
-	PythonGroundedObject(PyObject *object, bool unwrap_args);
+	PythonGroundedObject(void *object, bool unwrap_args);
 	virtual ~PythonGroundedObject();
 
 	virtual GroundedFunction get_method(std::string const& method_name);
 	virtual ValuePtr invoke(std::string const& method_name,
 							AtomSpace* atomspace, ValuePtr const& _args);
 
-	PyObject* get_object() const { return object; }
+	void* get_object() const { return object; }
 };
 
 }

--- a/opencog/cython/opencog/grounded_object_node.pxd
+++ b/opencog/cython/opencog/grounded_object_node.pxd
@@ -8,8 +8,8 @@ cdef extern from "opencog/atoms/execution/GroundedObject.h" namespace "opencog":
 
 cdef extern from "opencog/cython/opencog/PythonGroundedObject.h":
     cdef cppclass cPythonGroundedObject "opencog::PythonGroundedObject" (cGroundedObject):
-        cPythonGroundedObject(PyObject* object, bool unwrap_args)
-        object get_object() const
+        cPythonGroundedObject(void* object, bool unwrap_args)
+        void* get_object() const
 
 cdef extern from "opencog/atoms/execution/GroundedObjectNode.h" namespace "opencog":
     cdef cppclass cGroundedObjectNode "opencog::GroundedObjectNode":

--- a/opencog/cython/opencog/grounded_object_node.pyx
+++ b/opencog/cython/opencog/grounded_object_node.pyx
@@ -58,7 +58,6 @@ cdef api cValuePtr call_python_method(bool unwrap_args, void* obj,
 cdef cValuePtr call_unwrapped_args(object method, const cValuePtr& _args):
     args = convert_vector_of_grounded_objects_to_python_list((<cAtom*>_args.get()).getOutgoingSet())
     result = method(*args)
-    Py_INCREF(result)
     return <cValuePtr>create_grounded_object_node_from_python_object(result, True)
 
 cdef convert_vector_of_grounded_objects_to_python_list(vector[cHandle] handles):
@@ -74,7 +73,6 @@ cdef convert_vector_of_grounded_objects_to_python_list(vector[cHandle] handles):
         gon = <cGroundedObjectNode*>(handle.get())
         py_gon = <cPythonGroundedObject*>gon.get_object()
         obj = <object>py_gon.get_object()
-        Py_INCREF(obj)
         result.append(obj)
         inc(handle_iter)
     return result

--- a/opencog/cython/opencog/grounded_object_node.pyx
+++ b/opencog/cython/opencog/grounded_object_node.pyx
@@ -9,7 +9,7 @@ def createGroundedObjectNode(name, obj, atomspace, unwrap_args):
     cdef shared_ptr[cGroundedObjectNode] node_ptr
     cdef string node_name = <bytes>(name.encode())
     if obj is not None:
-        o_ptr.reset(new cPythonGroundedObject(<PyObject*>obj, unwrap_args))
+        o_ptr.reset(new cPythonGroundedObject(<void*>obj, unwrap_args))
         node_ptr.reset(new cGroundedObjectNode(node_name, o_ptr))
     else:
         node_ptr.reset(new cGroundedObjectNode(node_name))
@@ -19,7 +19,7 @@ def createGroundedObjectNode(name, obj, atomspace, unwrap_args):
 
 cdef cGroundedObjectNodePtr create_grounded_object_node_from_python_object(object obj, bool unwrap_args):
     cdef shared_ptr[cGroundedObject] o_ptr
-    o_ptr.reset(new cPythonGroundedObject(<PyObject*>obj, unwrap_args))
+    o_ptr.reset(new cPythonGroundedObject(<void*>obj, unwrap_args))
     cdef shared_ptr[cGroundedObjectNode] node_ptr
     node_ptr.reset(new cGroundedObjectNode("", o_ptr))
     return node_ptr
@@ -34,7 +34,7 @@ cdef class GroundedObjectNode(Atom):
 
     def set_object(self, obj, unwrap_args = False):
         cdef shared_ptr[cGroundedObject] o_ptr
-        o_ptr.reset(new cPythonGroundedObject(<PyObject*>obj, unwrap_args))
+        o_ptr.reset(new cPythonGroundedObject(<void*>obj, unwrap_args))
         self.get_c_grounded_object_node_ptr().set_object(o_ptr)
 
     def get_object(self):
@@ -42,13 +42,13 @@ cdef class GroundedObjectNode(Atom):
         if not gon.has_object():
             return None
         cdef cPythonGroundedObject* py_gon = <cPythonGroundedObject*>gon.get_object()
-        return py_gon.get_object()
+        return <object>py_gon.get_object()
 
-cdef api cValuePtr call_python_method(bool unwrap_args, object obj,
+cdef api cValuePtr call_python_method(bool unwrap_args, void* obj,
                                       const string& method_name,
                                       cAtomSpace* atomspace, const cValuePtr&
                                       args):
-    method = getattr(obj, method_name.c_str().decode())
+    method = getattr(<object>obj, method_name.c_str().decode())
     assert args.get().is_link()
     if unwrap_args:
         return call_unwrapped_args(method, args)
@@ -73,7 +73,7 @@ cdef convert_vector_of_grounded_objects_to_python_list(vector[cHandle] handles):
         assert handle.get().get_type() == types.GroundedObjectNode
         gon = <cGroundedObjectNode*>(handle.get())
         py_gon = <cPythonGroundedObject*>gon.get_object()
-        obj = py_gon.get_object()
+        obj = <object>py_gon.get_object()
         Py_INCREF(obj)
         result.append(obj)
         inc(handle_iter)

--- a/tests/cython/atomspace/test_groundedobjectnode.py
+++ b/tests/cython/atomspace/test_groundedobjectnode.py
@@ -5,6 +5,7 @@ from opencog.utilities import initialize_opencog, finalize_opencog
 from opencog.type_constructors import *
 from opencog.bindlink import execute_atom
 import __main__
+import sys
 
 class GroundedObjectNodeTest(unittest.TestCase):
 
@@ -156,6 +157,14 @@ class GroundedObjectNodeTest(unittest.TestCase):
         result = execute_atom(self.space, bind_link)
 
         self.assertEqual(result, SetLink(first, second))
+
+    def test_get_object(self):
+        obj = TestObject("some object")
+        gon = GroundedObjectNode("a", obj)
+        refc = sys.getrefcount(obj)
+
+        name = gon.get_object().name
+        self.assertEqual(refc, sys.getrefcount(obj))
 
 def return_true(atom):
     return TruthValue(1.0, 1.0)


### PR DESCRIPTION
Fix for https://github.com/singnet/atomspace/issues/83.

Python automatically decrements object reference counter if object is returned from Cython code. To prevent this object can be kept as `void*` in C code and casted to `object` in Cython layer. This tells Cython that reference is borrowed and it automatically increments reference counter.