### PR TITLE
Pass correctly wrapped args to python GroundedPredicateNode

### DIFF
--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -3,7 +3,7 @@ cdef class Atom(Value):
 
     @staticmethod
     cdef Atom createAtom(const cHandle& handle, AtomSpace a):
-        return Atom(PtrHolder.create(<shared_ptr[void]&>handle), a)
+        return create_python_value_from_c_value(<const cValuePtr&>handle, a)
 
     def __init__(self, ptr_holder, atomspace):
         super(Atom, self).__init__(ptr_holder)

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -201,7 +201,7 @@ cdef class AtomSpace:
     cdef object parent_atomspace
 
 
-cdef create_python_value_from_c_value(cValuePtr& value, AtomSpace atomspace)
+cdef create_python_value_from_c_value(const cValuePtr& value, AtomSpace atomspace)
 
 # FloatValue
 cdef extern from "opencog/atoms/value/FloatValue.h" namespace "opencog":

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -248,8 +248,7 @@ cdef api object py_atomspace(cAtomSpace *c_atomspace) with gil:
     return atomspace
 
 cdef api object py_atom(const cHandle& h, object atomspace):
-    cdef Atom atom = Atom.createAtom(h, atomspace)
-    return atom
+    return Atom.createAtom(h, atomspace)
 
 def create_child_atomspace(object atomspace):
     cdef cAtomSpace * child = new cAtomSpace((<AtomSpace>(atomspace)).atomspace)

--- a/opencog/cython/opencog/nameserver.pyx
+++ b/opencog/cython/opencog/nameserver.pyx
@@ -67,7 +67,7 @@ def get_refreshed_types():
     types = type('atom_types', (), generate_type_module())
     return types
 
-cdef create_python_value_from_c_value(cValuePtr& value, AtomSpace atomspace):
+cdef create_python_value_from_c_value(const cValuePtr& value, AtomSpace atomspace):
     type = value.get().get_type()
     type_name = get_type_name(type)
     ptr_holder = PtrHolder.create(<shared_ptr[void]&>value)

--- a/tests/cython/atomspace/test_groundedobjectnode.py
+++ b/tests/cython/atomspace/test_groundedobjectnode.py
@@ -165,11 +165,33 @@ class GroundedObjectNodeTest(unittest.TestCase):
 
         name = gon.get_object().name
         self.assertEqual(refc, sys.getrefcount(obj))
+    def test_pass_correctly_wrapped_args_to_python_grounded_predicate_node(self):
+        obj = GroundedObjectNode("obj", TestObject("some obj"), unwrap_args = True)
+        bindlink = BindLink(
+                TypedVariableLink(VariableNode("$X"),
+                                  TypeNode("GroundedObjectNode")),
+                AndLink(
+                    EvaluationLink(
+                        GroundedPredicateNode("py: float_to_truth_value"),
+                        ApplyLink(MethodOfLink(VariableNode("$X"),
+                                               ConceptNode("truth")),
+                                  ListLink()))
+                ),
+                VariableNode("$X")
+        )
+
+        result = execute_atom(self.space, bindlink)
+
+        self.assertEqual(result, SetLink(obj))
 
 def return_true(atom):
     return TruthValue(1.0, 1.0)
 
+def float_to_truth_value(atom):
+    return TruthValue(*atom.get_object())
+
 __main__.return_true = return_true
+__main__.float_to_truth_value = float_to_truth_value
 
 class TestObject:
 
@@ -190,6 +212,9 @@ class TestObject:
 
     def plain_multiply(self, a, b):
         return a * b
+
+    def truth(self):
+        return (1.0, 1.0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
PythonEval use py_atom() function to wrap C++ atom into Python one
before calling Python GroundedObjectNode function. py_atom() in turn use
Atom.createAtom() method passing C++ handle into it. Atom.createAtom()
should check C++ handle type to return correct Python wrapper for the
C++ atom. This commit fixed the issue and added unit test.