### PR TITLE
Allow using functions as links arguments to return calculated atom

### DIFF
--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -191,6 +191,9 @@ static void check_type(const ValuePtr& value, const Type& type, const std::strin
     if (nameserver().isA(value->get_type(), VARIABLE_NODE))
         return;
 
+    if (nameserver().isA(value->get_type(), FUNCTION_LINK))
+        return;
+
     if (!nameserver().isA(value->get_type(), type))
     {
         throw SyntaxException(TRACE_INFO,


### PR DESCRIPTION
Allow using function like `ApplyLink` as arguments to `Link` to execute result.