### PR TITLE
Acquire GIL in PythonGroundedObject

### DIFF
--- a/opencog/cython/opencog/PythonGroundedObject.cc
+++ b/opencog/cython/opencog/PythonGroundedObject.cc
@@ -65,9 +65,27 @@ GroundedFunction PythonGroundedObject::get_method(std::string const& method_name
 			std::placeholders::_1, std::placeholders::_2);
 }
 
+class PyLockGIL
+{
+
+private:
+	PyGILState_STATE gstate;
+
+public:
+	PyLockGIL() : gstate(PyGILState_Ensure())
+	{
+	}
+
+	~PyLockGIL()
+	{
+		PyGILState_Release(gstate);
+	}
+};
+
 ValuePtr PythonGroundedObject::invoke(std::string const& method_name,
 						AtomSpace* atomspace, ValuePtr const& args)
 {
+	PyLockGIL gil;
 	return call_python_method(unwrap_args, object, method_name, atomspace, args);
 }
 

--- a/tests/cython/atomspace/test_groundedobjectnode_gil.py
+++ b/tests/cython/atomspace/test_groundedobjectnode_gil.py
@@ -1,0 +1,82 @@
+import time
+import unittest
+
+from opencog.atomspace import AtomSpace
+from opencog.utilities import initialize_opencog, finalize_opencog
+from opencog.type_constructors import *
+from opencog.scheme_wrapper import scheme_eval
+
+
+class Point:
+
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def get_x(self):
+        return self.x
+
+    def get_y(self):
+        return self.x
+
+    def move(self, x, y):
+        self.x += x
+        self.y += y
+
+    def __str__(self):
+        return "Point(%d, %d)" % (self.x, self.y)
+
+
+class GroundedObjectNodeGilTest(unittest.TestCase):
+
+    def setUp(self):
+        self.atomspace = AtomSpace()
+        initialize_opencog(self.atomspace)
+
+    def tearDown(self):
+        finalize_opencog()
+        del self.atomspace
+
+    def test_call_grounded_object_call(self):
+        point = Point(2, 3)
+
+        GroundedObjectNode("point", point, unwrap_args=True)
+        GroundedObjectNode("x", 3)
+        GroundedObjectNode("y", 4)
+
+        scheme_eval(self.atomspace,
+                    '''
+                    (use-modules
+                     (opencog)
+                     (opencog exec))
+
+                    (define (async-call f n)
+                     (call-with-new-thread f)
+                     (if (> n 1)
+                      (async-call f (- n 1))
+                     ))
+                    (async-call (lambda ()
+                      (begin
+                        (define apply-link
+                            (ApplyLink
+                              (MethodOfLink
+                                (GroundedObjectNode "point")
+                                (ConceptNode "move"))
+                              (ListLink
+                                (GroundedObjectNode "x")
+                                (GroundedObjectNode "y"))))
+                        (cog-execute! apply-link)
+                        )) 10)
+
+                    (usleep 500)
+                    ''')
+
+        time.sleep(0.2)
+
+        N = 10
+        self.assertEqual(2 + 3 * N, point.x)
+        self.assertEqual(3 + 4 * N, point.y)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The fix takes GIL in PythonGroundedObject::invoke(...) method to avoid crash when a PythonGroundedObject is used from different threads.