### PR TITLE
expanded make-score-fn to adjust scores with distance weights

### DIFF
--- a/opencog/sheaf/mst-parser.scm
+++ b/opencog/sheaf/mst-parser.scm
@@ -38,12 +38,15 @@
 
 ; ---------------------------------------------------------------------
 
-(define-public (make-score-fn LLOBJ METHOD)
+(define-public (make-score-fn-dist LLOBJ METHOD DIST-MULTS)
 "
   make-score-fn LLOBJ METHOD -- Create a function that returns a
   score for a pair of atoms, the score being given by invoking
   METHOD on LLOBJ.  The LLOBJ must provide the METHOD, of course,
   and also the 'get-pair method, so that pairs can be assembled.
+  The list DIST-MULTS contains multipliers for the score for each
+  possible integer distance between the atoms. For distances longer 
+  than the range of the list, the list's last value is used as multiplier.
 
   If either atom is nil, or if the atom-pair cannot be found, then a
   default value of -1e40 is returned.
@@ -60,8 +63,15 @@
 			(if (and (not (null? left-atom)) (not (null? right-atom)))
 				(LLOBJ 'get-pair left-atom right-atom)
 				'()))
-		(if (null? wpr) bad-mi (LLOBJ METHOD wpr))
+		(define multiplier (list-ref DIST-MULTS (- (min distance (length DIST-MULTS)) 1)))
+
+		(if (null? wpr) bad-mi (* multiplier (LLOBJ METHOD wpr)))
 	)
+)
+
+; backward compatibility for make-score-fn
+(define-public (make-score-fn LLOBJ METHOD)
+	(make-score-fn-dist LLOBJ METHOD '(1))
 )
 
 ; ---------------------------------------------------------------------


### PR DESCRIPTION
make-score-fn-dist creates a scoring function that takes a list (DIST-MULTS) that contains multipliers for an atom-pair score depending on the distance between atoms.
Distances have to be positive integers.
if we have a distance-modifying function     f(x), x E [1,2,..,infty]
f(x) = xth-element of DIST-MULTS, if x < size(DIST-MULTS)
f(x) = last-element of DIST-MULTS, if x >= size(DIST-MULTS)

The distance-modifying score will be: modified_score = f(x) * original_score